### PR TITLE
Add Telemetry Tab for Moteus Controllers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,7 +38,11 @@ const exampleData = exampleSub(ros);
 
 <template>
   <Navbar />
-  <RouterView />
+  <router-view v-slot="{ Component }">
+    <KeepAlive>
+      <component :is="Component"></component>
+    </KeepAlive>
+  </router-view>
 </template>
 
 <style lang="scss">

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,10 +17,10 @@ const test = ref<number>(10001);
 
 // Create ros object to communicate over your Rosbridge connection
 // local host development
-const { ros, isWebSocketConnected } = rosInit('ws://localhost:9090');
+//const { ros, isWebSocketConnected } = rosInit('ws://localhost:9090');
 
 // Connects to the router
-// const { ros, isWebSocketConnected } = rosInit('ws://192.168.0.145:9090');
+ const { ros, isWebSocketConnected } = rosInit('ws://192.168.0.145:9090');
 
 // Connects to rover
 // const { ros, isWebSocketConnected } = rosInit('ws://10.0.0.10:9090');

--- a/src/components/DropDownItem.vue
+++ b/src/components/DropDownItem.vue
@@ -1,27 +1,6 @@
-<script>
-    import { ref, onMounted } from 'vue'
-
-    export default{
-        props: {
-            itemName: String,
-            isSelected: Boolean
-        }
-    }
-
-    
-
-
-    
+<script setup>
+  const props = defineProps(['itemName', 'isSelected']);    
 </script>
-
-<!--script setup>
-    var isSelected = ref(false);
-
-    defineExpose({
-        isSelected
-    })
-</script-->
-
 
 
 <template>

--- a/src/components/DropDownItem.vue
+++ b/src/components/DropDownItem.vue
@@ -1,0 +1,63 @@
+<script>
+    import { ref, onMounted } from 'vue'
+
+    export default{
+        props: {
+            itemName: String
+        }
+    }
+
+    
+
+
+    
+</script>
+
+<script setup>
+    var isSelected = ref(false);
+</script>
+
+
+
+<template>
+    <div class="dropdown-item mycontainer prevent-select" @click="$emit('callback')">
+        <div class="item-text" @click="isSelected = !isSelected"><span>{{ itemName }}</span></div>
+        <div class="item-checkmark" v-if="isSelected">✓</div>
+
+      </div>
+
+</template>
+
+
+<style>
+
+.mycontainer {
+  display: flex;
+
+  justify-content: space-between;
+  
+}
+
+.item-text{
+  font-weight: bolder;
+  
+  flex-grow: 1;
+}
+
+.item-checkmark{
+  font-weight: bolder;
+  
+}
+
+.prevent-select {
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10 and IE 11 */
+  user-select: none; /* Standard syntax */
+}
+
+
+.dropdown-item {
+  color: blue;
+}
+
+</style>

--- a/src/components/DropDownItem.vue
+++ b/src/components/DropDownItem.vue
@@ -3,7 +3,8 @@
 
     export default{
         props: {
-            itemName: String
+            itemName: String,
+            isSelected: Boolean
         }
     }
 
@@ -13,16 +14,22 @@
     
 </script>
 
-<script setup>
+<!--script setup>
     var isSelected = ref(false);
-</script>
+
+    defineExpose({
+        isSelected
+    })
+</script-->
 
 
 
 <template>
     <div class="dropdown-item mycontainer prevent-select" @click="$emit('callback')">
-        <div class="item-text" @click="isSelected = !isSelected"><span>{{ itemName }}</span></div>
-        <div class="item-checkmark" v-if="isSelected">✓</div>
+        <div class="item-text"><span>{{ itemName }}</span></div>
+        <div class="item-checkmark" >
+            <b v-if="isSelected">✓</b>
+        </div>
 
       </div>
 
@@ -40,8 +47,6 @@
 
 .item-text{
   font-weight: bolder;
-  
-  flex-grow: 1;
 }
 
 .item-checkmark{

--- a/src/components/DropDownItem.vue
+++ b/src/components/DropDownItem.vue
@@ -69,3 +69,5 @@
     background-color: rgb(161, 161, 161);
     border-radius: 7px;
 }
+
+</style>

--- a/src/components/DropDownItem.vue
+++ b/src/components/DropDownItem.vue
@@ -25,7 +25,7 @@
 
 
 <template>
-    <div class="dropdown-item mycontainer prevent-select" @click="$emit('callback')">
+    <div class="dropdown-item mycontainer prevent-select hover-highlight" @click="$emit('callback')">
         <div class="item-text"><span>{{ itemName }}</span></div>
         <div class="item-checkmark" >
             <b v-if="isSelected">✓</b>
@@ -40,7 +40,7 @@
 
 .mycontainer {
   display: flex;
-
+  margin: 2px;
   justify-content: space-between;
   
 }
@@ -65,4 +65,7 @@
   color: blue;
 }
 
-</style>
+.hover-highlight:hover {
+    background-color: rgb(161, 161, 161);
+    border-radius: 7px;
+}

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -9,16 +9,20 @@ import ROSLIB, { Ros } from 'roslib';
 
 onMounted(() => initialize());
 
-const props = defineProps(['moteusCANID', 'displayName', 'preset', 'dataSub']);
+const props = defineProps(['moteusCANID', 'displayName', 'preset', 'dataSub', 'update_ms']);
 
 const possiblePresets = ["FULL", "IMPORTANT"];
 
-const UPDATE_DATA_MS = 100;//Update the data ever 100ms
+//const UPDATE_DATA_MS = 100;//Update the data ever 100ms
 let isRecordingData = false;
 let csvDataObjects :object[] = [];
 let showCheckbox = ref(true);
 
 let recordButtonText = ref("Start Recording")
+
+//let pollingData = setInterval(readDataCallback, 100);//default 4ms per browser
+let pollingData;
+
 
 const moteuesDataChoice = [
   {
@@ -99,12 +103,15 @@ function initialize() {
     moteuesDataChoice[6].isSelected.value = false;
   }
 
-  setInterval(readDataCallback, UPDATE_DATA_MS);
+  pollingData = setInterval(readDataCallback, 500);//default 100
 
 };
 
 
 function readDataCallback(){
+  //setTimeout(props.update_ms)
+  
+
   if (props.dataSub.value == "" || props.dataSub.value == undefined) {
     return -1
   }
@@ -140,6 +147,16 @@ function readDataCallback(){
       }
 
     }
+
+    clearInterval(pollingData)
+    
+    if (props.update_ms < 4) {
+      pollingData = setInterval(readDataCallback, 100)
+    }
+    else{
+      pollingData = setInterval(readDataCallback, props.update_ms)
+    }
+
 
 
   }

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -1,37 +1,84 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue'
 import DropDownItem from "../components/DropDownItem.vue"
+import { render, h } from 'vue'
 
 onMounted(() => initialize());
 
 
-var raw_html = ref("");
 
-const possibleChoices = new Set([
-  "canID",
-  "position",
-  "velocity",
-  "torque",
-  "temperature",
-  "power",
-  "inputVoltage"
-]);
+const moteuesDataChoice = [
+  {
+    prettyName: "CAN ID",
+    identifier: "canID",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Position",
+    identifier: "position",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Velocity",
+    identifier: "velocity",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Torque",
+    identifier: "torque",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Temperature",
+    identifier: "temperature",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Power",
+    identifier: "power",
+    dataValue: -1,
+    isSelected: ref(false)
+  },
+  {
+    prettyName: "Input Voltage",
+    identifier: "inputVoltage",
+    dataValue: -1,
+    isSelected: ref(true)
+  },
 
+]
 
+const canID = ref(null);
 
 function initialize() {
 
 
-
-  //alert("setting up page")
 };
 
 
 function itemClicked(itemName: String) {
   //alert(itemName)
-
+  let mything = getMoteusObject(itemName);
+  if (mything != null) {
+    mything.isSelected.value = !mything.isSelected.value;
+  }
   
 
+}
+
+function getMoteusObject(itemName: String){
+  for (let index = 0; index < moteuesDataChoice.length; index++) {
+    if (moteuesDataChoice[index].identifier == itemName) {
+      return moteuesDataChoice[index];
+    }
+  }
+
+  return null;
 }
 
 </script>
@@ -39,14 +86,24 @@ function itemClicked(itemName: String) {
 
 
 <template>
-  <div style="border: 2px solid RED;">
-    Welcome to the moteusmotortelemetry
+  <div class="dropdown" style="border: 2px solid RED;">
+    <button class="dropbtn">Dropdown</button>
+    <div class="dropdown-content">
+      <DropDownItem
+        v-for="(item) in moteuesDataChoice"
+        @callback="itemClicked(item.identifier)"
+        v-bind:itemName="item.prettyName"
+        v-bind:isSelected="item.isSelected.value"
+      ></DropDownItem>
+
+    </div>
+
+
   </div>
 
-
-  <div class="dropdown">
+  <!--div class="dropdown" style="border: 2px solid RED;">
     <button class="dropbtn">Dropdown</button>
-    <!--div class="dropdown-content" v-html="raw_html"></div-->
+    <div class="dropdown-content" v-html="raw_html"></di>
     <div class="dropdown-content">
       <DropDownItem ref="canIDref" @callback="itemClicked('canID')" itemName="canID"></DropDownItem>
       <DropDownItem @callback="itemClicked('position')" itemName="position"></DropDownItem>
@@ -55,19 +112,13 @@ function itemClicked(itemName: String) {
       <DropDownItem @callback="itemClicked('temperature')" itemName="temperature"></DropDownItem>
       <DropDownItem @callback="itemClicked('power')" itemName="power"></DropDownItem>
       <DropDownItem @callback="itemClicked('inputVoltage')" itemName="inputVoltage"></DropDownItem>
-      
-
-      <!--div class="dropdown-item flex-container" @click="itemClicked('ahhh')">
-        <div class="item">ahhh</div>
-        <div class="item">✓</div-->
-
-      
-
-
-
-
     </div>
   </div>
+
+  <div>
+      <b>canID: </b>
+      <b>{{canIDVal}}</b>
+  </div-->
 
 
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -15,6 +15,8 @@ const possiblePresets = ["FULL", "IMPORTANT"];
 
 const UPDATE_DATA_MS = 100;//Update the data ever 100ms
 let isRecordingData = false;
+let csvDataObjects :object[] = []
+
 
 const moteuesDataChoice = [
   {
@@ -113,12 +115,6 @@ function setupSubscriber(){
 
 
 function readDataCallback(){
-  if (moteuesDataChoice != undefined) {
-   //console.log(moteuesDataChoice[0].shouldRecordData.value)
-
-  }
-
-
   if (sub.value == "" || sub.value == undefined) {
     return -1
   }
@@ -138,6 +134,28 @@ function readDataCallback(){
       moteuesDataChoice[4].dataValue.value = String(moteusMotorEntry.temperature).substring(0,6);
       moteuesDataChoice[5].dataValue.value = String(moteusMotorEntry.power).substring(0,6);
       moteuesDataChoice[6].dataValue.value = String(moteusMotorEntry.inputVoltage).substring(0,6);
+
+      if (isRecordingData) {
+        let tempDataArray: any[] = [];
+        
+        for (let index = 0; index < 7; index++) {
+          let entry = moteuesDataChoice[index];
+
+          if (entry.shouldRecordData.value == true) {
+
+            tempDataArray.push(entry.dataValue.value)
+
+          }
+        }
+
+        csvDataObjects.push(tempDataArray)
+
+
+
+        
+
+      }
+
     }
 
 
@@ -161,13 +179,60 @@ let recordButtonText = ref("Start Recording")
 function recordButtonPressed(){
   if (!isRecordingData) {
     recordButtonText.value = "Stop Recording" 
+    csvDataObjects = []
 
     //Create file
-    
-    
   }
   else {
     recordButtonText.value = "Start Recording" 
+
+    //Create and save the file
+    let csvString = "";
+    csvString += createrHeaderString();
+
+    for (let fullEntryIndex = 0; fullEntryIndex < csvDataObjects.length; fullEntryIndex++) {
+      let entryArray = csvDataObjects[fullEntryIndex];
+      let entryString = ""
+
+      for (let dataIndex = 0; dataIndex < entryArray.length; dataIndex++) {
+        entryString += "" + entryArray[dataIndex] + ","
+      }
+
+      entryString = entryString.substring(0, entryString.length - 1) + "\n"
+
+      csvString += entryString
+
+    }
+
+    console.log(csvString)
+
+    // const download = (data) => {
+    // // Create a Blob with the CSV data and type
+    // const blob = new Blob([data], { type: 'text/csv' });
+    
+    // // Create a URL for the Blob
+    // const url = URL.createObjectURL(blob);
+    
+    // // Create an anchor tag for downloading
+    // const a = document.createElement('a');
+    
+    // // Set the URL and download attribute of the anchor tag
+    // a.href = url;
+    // a.download = 'download.csv';
+    
+    // // Trigger the download by clicking the anchor tag
+    // a.click();
+    // }
+
+    const blob = new Blob([csvString], {type: 'text.csv'})
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.download = "data.csv"
+    a.href = url;
+
+    a.click();
+
+
 
     // const data = JSON.stringify({'hello': 1})
     // const blob = new Blob([data], {type: 'text/plain'})
@@ -183,9 +248,23 @@ function recordButtonPressed(){
   }
 
   isRecordingData = !isRecordingData;
+}
 
 
 
+
+function createrHeaderString(){
+  let headerString = "";
+
+  for (let index = 0; index < 7; index++) {
+    let entry = moteuesDataChoice[index];
+
+    if (entry.shouldRecordData.value == true) {
+      headerString += entry.identifier + ","
+    }
+  }
+
+  return headerString.substring(0,headerString.length - 1) + "\n";// Get rid of the last comma
 
 }
 
@@ -245,7 +324,7 @@ function checkboxClicked(name: String){
       
         </div>
   
-        <div class="moteus-reminder">Motor Controller: <b>Moteus</b></div>
+        <!--div class="moteus-reminder">Motor Controller: <b>Moteus</b></div-->
 
       </div>
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -15,12 +15,10 @@ const possiblePresets = ["FULL", "IMPORTANT"];
 
 const UPDATE_DATA_MS = 100;//Update the data ever 100ms
 let isRecordingData = false;
-let csvDataObjects :object[] = []
+let csvDataObjects :object[] = [];
+let showCheckbox = ref(true);
 
-
-let sub;
 let recordButtonText = ref("Start Recording")
-
 
 const moteuesDataChoice = [
   {
@@ -78,8 +76,6 @@ const moteuesDataChoice = [
 function initialize() {
   moteuesDataChoice[0].dataValue.value = props.moteusCANID;
 
-  //console.log(sub)
-  
 
   // FULL
   if (props.preset == possiblePresets[0]) {
@@ -127,11 +123,11 @@ function readDataCallback(){
       moteuesDataChoice[5].dataValue.value = String(moteusMotorEntry.power).substring(0,6);
       moteuesDataChoice[6].dataValue.value = String(moteusMotorEntry.inputVoltage).substring(0,6);
 
-      
+      // Data recording stuff
       if (isRecordingData) {
         let tempDataArray: any[] = [];
         
-        for (let index = 0; index < 7; index++) {
+        for (let index = 0; index < moteuesDataChoice.length; index++) {
           let entry = moteuesDataChoice[index];
 
           if (entry.shouldRecordData.value == true) {
@@ -140,13 +136,7 @@ function readDataCallback(){
 
           }
         }
-
         csvDataObjects.push(tempDataArray)
-
-
-
-        
-
       }
 
     }
@@ -156,7 +146,7 @@ function readDataCallback(){
   
 }
 
-
+// Used for the dropdown menu
 function itemClicked(itemName: String) {
   let mything = getMoteusDataObjectFromIdentifier(itemName);
   if (mything != null) {
@@ -166,18 +156,18 @@ function itemClicked(itemName: String) {
 
 }
 
-
-
-
 function recordButtonPressed(){
   if (!isRecordingData) {
     recordButtonText.value = "Stop Recording" 
+    showCheckbox.value = false;
+
+    // reset the data
     csvDataObjects = []
 
-    //Create file
   }
   else {
     recordButtonText.value = "Start Recording" 
+    showCheckbox.value = true
 
     //Create and save the file
     let csvString = "";
@@ -199,57 +189,16 @@ function recordButtonPressed(){
 
     console.log(csvString)
 
-    // const download = (data) => {
-    // // Create a Blob with the CSV data and type
-    // const blob = new Blob([data], { type: 'text/csv' });
-    
-    // // Create a URL for the Blob
-    // const url = URL.createObjectURL(blob);
-    
-    // // Create an anchor tag for downloading
-    // const a = document.createElement('a');
-    
-    // // Set the URL and download attribute of the anchor tag
-    // a.href = url;
-    // a.download = 'download.csv';
-    
-    // // Trigger the download by clicking the anchor tag
-    // a.click();
-    // }
-
-    const blob = new Blob([csvString], {type: 'text.csv'})
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.download = "data.csv"
-    a.href = url;
-
-    a.click();
-
-
-
-    // const data = JSON.stringify({'hello': 1})
-    // const blob = new Blob([data], {type: 'text/plain'})
-    // const e = document.createEvent('MouseEvents'),
-    // a = document.createElement('a');
-    // a.download = "test.json";
-    // a.href = window.URL.createObjectURL(blob);
-    // a.dataset.downloadurl = ['text/json', a.download, a.href].join(':');
-    // //idk I copy pasted this code
-    // e.initEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    // a.dispatchEvent(e);
-
   }
 
   isRecordingData = !isRecordingData;
 }
 
 
-
-
 function createrHeaderString(){
   let headerString = "";
 
-  for (let index = 0; index < 7; index++) {
+  for (let index = 0; index < moteuesDataChoice.length; index++) {
     let entry = moteuesDataChoice[index];
 
     if (entry.shouldRecordData.value == true) {
@@ -333,7 +282,8 @@ function checkboxClicked(name: String){
           v-bind:isSelected="item.isSelected.value"
           v-bind:value="item.dataValue.value"
           v-bind:shouldRecordData="item.shouldRecordData.value"
-          @checkboxClicked="checkboxClicked">
+          @checkboxClicked="checkboxClicked"
+          v-bind:shouldShowCheckBox="showCheckbox">
         </TelemetryDataDisplay>
       </div>
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -9,7 +9,7 @@ import ROSLIB, { Ros } from 'roslib';
 
 onMounted(() => initialize());
 
-const props = defineProps(['moteusCANID', 'displayName', 'preset', 'dataSub', 'update_ms']);
+const props = defineProps(['moteusCANID', 'displayName', 'preset', 'dataSub', 'update_ms','showAllFeatures']);
 
 const possiblePresets = ["FULL", "IMPORTANT"];
 
@@ -79,6 +79,7 @@ const moteuesDataChoice = [
 
 function initialize() {
   moteuesDataChoice[0].dataValue.value = props.moteusCANID;
+
 
 
   // FULL
@@ -294,7 +295,7 @@ function checkboxClicked(name: String){
       </div>
 
       <div>
-        <button id="record_button" v-bind:class="{'record-button-green': !isRecordingData, 'record-button-red': isRecordingData}" @click="recordButtonPressed">{{ recordButtonText }}</button>
+        <button v-if="showAllFeatures" id="record_button" v-bind:class="{'record-button-green': !isRecordingData, 'record-button-red': isRecordingData}" @click="recordButtonPressed">{{ recordButtonText }}</button>
       </div>
 
     
@@ -306,7 +307,8 @@ function checkboxClicked(name: String){
           v-bind:value="item.dataValue.value"
           v-bind:shouldRecordData="item.shouldRecordData.value"
           @checkboxClicked="checkboxClicked"
-          v-bind:shouldShowCheckBox="showCheckbox">
+          v-bind:shouldShowCheckBox="showCheckbox"
+          v-bind:showAllFeatures="showAllFeatures">
         </TelemetryDataDisplay>
       </div>
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -58,6 +58,8 @@ const moteuesDataChoice = [
 
 function initialize() {
   console.log(props.moteusCANID)
+  moteuesDataChoice[0].dataValue = props.moteusCANID;
+  
 
   // FULL
   if (props.preset == possiblePresets[0]) {
@@ -112,23 +114,29 @@ function getMoteusObject(itemName: String){
   <div class="module-bg">
     
       <div>
-        <b style="font-size:x-large;">{{ displayName }}</b>
+        <b style="font-size:large;">{{ displayName }}</b>
       </div>
-    
-      <div class="dropdown">
-        <button class="drop-button">Select</button>
-        <div class="dropdown-content">
-          <DropDownItem
-            v-for="(item) in moteuesDataChoice"
-            @callback="itemClicked(item.identifier)"
-            v-bind:itemName="item.prettyName"
-            v-bind:isSelected="item.isSelected.value"
-          ></DropDownItem>
-    
+      
+      <div class="flex-container">
+        <div class="dropdown">
+            <button class="drop-button">Select</button>
+          <div class="dropdown-content">
+            <DropDownItem
+              v-for="(item) in moteuesDataChoice"
+              @callback="itemClicked(item.identifier)"
+              v-bind:itemName="item.prettyName"
+              v-bind:isSelected="item.isSelected.value"
+            ></DropDownItem>
+      
+          </div>
+      
+      
         </div>
-    
-    
+  
+        <div class="moteus-reminder">Motor Controller: <b>Moteus</b></div>
+
       </div>
+
     
       <div>
         <TelemetryDataDisplay 
@@ -157,9 +165,13 @@ function getMoteusObject(itemName: String){
   height: fit-content;
 }
 
+.moteus-reminder{
+  margin: 4px;
+}
+
 .flex-container {
   display: flex;
-  justify-content: space-between;
+  justify-content: left;
 }
 
 .item{

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -6,7 +6,9 @@ import { render, h } from 'vue'
 
 onMounted(() => initialize());
 
+const props = defineProps(['moteusCANID', 'displayName', 'preset']);
 
+const possiblePresets = ["FULL", "IMPORTANT"];
 
 const moteuesDataChoice = [
   {
@@ -55,7 +57,29 @@ const moteuesDataChoice = [
 ]
 
 function initialize() {
+  console.log(props.moteusCANID)
 
+  // FULL
+  if (props.preset == possiblePresets[0]) {
+    moteuesDataChoice[0].isSelected.value = true;
+    moteuesDataChoice[1].isSelected.value = true;
+    moteuesDataChoice[2].isSelected.value = true;
+    moteuesDataChoice[3].isSelected.value = true;
+    moteuesDataChoice[4].isSelected.value = true;
+    moteuesDataChoice[5].isSelected.value = true;
+    moteuesDataChoice[6].isSelected.value = true;
+
+  }
+  // IMPORTANT
+  else if (props.preset == possiblePresets[1]){
+    moteuesDataChoice[0].isSelected.value = false;
+    moteuesDataChoice[1].isSelected.value = true;
+    moteuesDataChoice[2].isSelected.value = true;
+    moteuesDataChoice[3].isSelected.value = false;
+    moteuesDataChoice[4].isSelected.value = false;
+    moteuesDataChoice[5].isSelected.value = false;
+    moteuesDataChoice[6].isSelected.value = false;
+  }
 
 };
 
@@ -85,28 +109,36 @@ function getMoteusObject(itemName: String){
 
 
 <template>
-  <div class="dropdown" style="border: 2px solid RED;">
-    <button class="dropbtn">Dropdown</button>
-    <div class="dropdown-content">
-      <DropDownItem
-        v-for="(item) in moteuesDataChoice"
-        @callback="itemClicked(item.identifier)"
-        v-bind:itemName="item.prettyName"
-        v-bind:isSelected="item.isSelected.value"
-      ></DropDownItem>
+  <div class="module-bg">
+    
+      <div>
+        <b style="font-size:x-large;">{{ displayName }}</b>
+      </div>
+    
+      <div class="dropdown">
+        <button class="drop-button">Select</button>
+        <div class="dropdown-content">
+          <DropDownItem
+            v-for="(item) in moteuesDataChoice"
+            @callback="itemClicked(item.identifier)"
+            v-bind:itemName="item.prettyName"
+            v-bind:isSelected="item.isSelected.value"
+          ></DropDownItem>
+    
+        </div>
+    
+    
+      </div>
+    
+      <div>
+        <TelemetryDataDisplay 
+          v-for="(item) in moteuesDataChoice"
+          v-bind:itemName="item.prettyName"
+          v-bind:isSelected="item.isSelected.value"
+          v-bind:value="item.dataValue">
+        </TelemetryDataDisplay>
+      </div>
 
-    </div>
-
-
-  </div>
-
-  <div>
-    <TelemetryDataDisplay 
-      v-for="(item) in moteuesDataChoice"
-      v-bind:itemName="item.prettyName"
-      v-bind:isSelected="item.isSelected.value"
-      v-bind:value="item.dataValue">
-    </TelemetryDataDisplay>
   </div>
 
 
@@ -116,6 +148,15 @@ function getMoteusObject(itemName: String){
 
 
 <style>
+
+.module-bg{
+  background-color: rgb(109, 109, 109);
+  border-radius: 20px;
+  padding: 10px;
+  width: 15%;
+  height: fit-content;
+}
+
 .flex-container {
   display: flex;
   justify-content: space-between;
@@ -127,24 +168,27 @@ function getMoteusObject(itemName: String){
 
 
 .dropdown-item {
-  color: blue;
+  color: black;
 }
 
 
-.dropbtn {
-  background-color: #04AA6D;
+.drop-button {
+  background-color: rgb(48, 182, 48);
   color: white;
-  padding: 16px;
+  padding: 8px;
   font-size: 16px;
   border: none;
+  border-radius: 10px;
 }
 
 .dropdown {
   position: relative;
   display: inline-block;
+  
 }
 
 .dropdown-content {
+  border-radius: 7px;
   display: none;
   position: absolute;
   background-color: #f1f1f1;
@@ -153,22 +197,11 @@ function getMoteusObject(itemName: String){
   z-index: 1;
 }
 
-.dropdown-content a {
-  color: black;
-  padding: 12px 16px;
-  text-decoration: none;
-  display: block;
-}
-
-.dropdown-content a:hover {
-  background-color: #ddd;
-}
-
 .dropdown:hover .dropdown-content {
   display: block;
 }
 
-.dropdown:hover .dropbtn {
-  background-color: #3e8e41;
+.dropdown:hover .drop-button {
+  background-color: rgb(22, 131, 28);
 }
 </style>

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue'
 import DropDownItem from "../components/DropDownItem.vue"
+import TelemetryDataDisplay from "../components/TelemetryDataDisplay.vue"
 import { render, h } from 'vue'
 
 onMounted(() => initialize());
@@ -48,12 +49,10 @@ const moteuesDataChoice = [
     prettyName: "Input Voltage",
     identifier: "inputVoltage",
     dataValue: -1,
-    isSelected: ref(true)
+    isSelected: ref(false)
   },
 
 ]
-
-const canID = ref(null);
 
 function initialize() {
 
@@ -101,24 +100,15 @@ function getMoteusObject(itemName: String){
 
   </div>
 
-  <!--div class="dropdown" style="border: 2px solid RED;">
-    <button class="dropbtn">Dropdown</button>
-    <div class="dropdown-content" v-html="raw_html"></di>
-    <div class="dropdown-content">
-      <DropDownItem ref="canIDref" @callback="itemClicked('canID')" itemName="canID"></DropDownItem>
-      <DropDownItem @callback="itemClicked('position')" itemName="position"></DropDownItem>
-      <DropDownItem @callback="itemClicked('velocity')" itemName="velocity"></DropDownItem>
-      <DropDownItem @callback="itemClicked('torque')" itemName="torque"></DropDownItem>
-      <DropDownItem @callback="itemClicked('temperature')" itemName="temperature"></DropDownItem>
-      <DropDownItem @callback="itemClicked('power')" itemName="power"></DropDownItem>
-      <DropDownItem @callback="itemClicked('inputVoltage')" itemName="inputVoltage"></DropDownItem>
-    </div>
+  <div>
+    <TelemetryDataDisplay 
+      v-for="(item) in moteuesDataChoice"
+      v-bind:itemName="item.prettyName"
+      v-bind:isSelected="item.isSelected.value"
+      v-bind:value="item.dataValue">
+    </TelemetryDataDisplay>
   </div>
 
-  <div>
-      <b>canID: </b>
-      <b>{{canIDVal}}</b>
-  </div-->
 
 
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -1,0 +1,133 @@
+<script lang="ts" setup>
+import { ref, onMounted } from 'vue'
+import DropDownItem from "../components/DropDownItem.vue"
+
+onMounted(() => initialize());
+
+
+var raw_html = ref("");
+
+const possibleChoices = new Set([
+  "canID",
+  "position",
+  "velocity",
+  "torque",
+  "temperature",
+  "power",
+  "inputVoltage"
+]);
+
+
+
+function initialize() {
+
+
+
+  //alert("setting up page")
+};
+
+
+function itemClicked(itemName: String) {
+  //alert(itemName)
+
+  
+
+}
+
+</script>
+
+
+
+<template>
+  <div style="border: 2px solid RED;">
+    Welcome to the moteusmotortelemetry
+  </div>
+
+
+  <div class="dropdown">
+    <button class="dropbtn">Dropdown</button>
+    <!--div class="dropdown-content" v-html="raw_html"></div-->
+    <div class="dropdown-content">
+      <DropDownItem ref="canIDref" @callback="itemClicked('canID')" itemName="canID"></DropDownItem>
+      <DropDownItem @callback="itemClicked('position')" itemName="position"></DropDownItem>
+      <DropDownItem @callback="itemClicked('velocity')" itemName="velocity"></DropDownItem>
+      <DropDownItem @callback="itemClicked('torque')" itemName="torque"></DropDownItem>
+      <DropDownItem @callback="itemClicked('temperature')" itemName="temperature"></DropDownItem>
+      <DropDownItem @callback="itemClicked('power')" itemName="power"></DropDownItem>
+      <DropDownItem @callback="itemClicked('inputVoltage')" itemName="inputVoltage"></DropDownItem>
+      
+
+      <!--div class="dropdown-item flex-container" @click="itemClicked('ahhh')">
+        <div class="item">ahhh</div>
+        <div class="item">✓</div-->
+
+      
+
+
+
+
+    </div>
+  </div>
+
+
+
+</template>
+
+
+<style>
+.flex-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.item{
+  font-weight: bolder;
+}
+
+
+.dropdown-item {
+  color: blue;
+}
+
+
+.dropbtn {
+  background-color: #04AA6D;
+  color: white;
+  padding: 16px;
+  font-size: 16px;
+  border: none;
+}
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f1f1f1;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+}
+
+.dropdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.dropdown-content a:hover {
+  background-color: #ddd;
+}
+
+.dropdown:hover .dropdown-content {
+  display: block;
+}
+
+.dropdown:hover .dropbtn {
+  background-color: #3e8e41;
+}
+</style>

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -13,55 +13,64 @@ const props = defineProps(['moteusCANID', 'displayName', 'preset']);
 
 const possiblePresets = ["FULL", "IMPORTANT"];
 
+const UPDATE_DATA_MS = 100;//Update the data ever 100ms
+let isRecordingData = false;
+
 const moteuesDataChoice = [
   {
     prettyName: "CAN ID",
     identifier: "canID",
-    dataValue: -1,
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Position",
     identifier: "position",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Velocity",
     identifier: "velocity",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Torque",
     identifier: "torque",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Temperature",
     identifier: "temperature",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Power",
     identifier: "power",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
   {
     prettyName: "Input Voltage",
     identifier: "inputVoltage",
-    dataValue: ref(-1),
-    isSelected: ref(false)
+    dataValue: ref("N/A"),
+    isSelected: ref(false),
+    shouldRecordData: ref(false)
   },
 
 ]
 
 function initialize() {
-  console.log(props.moteusCANID)
-  moteuesDataChoice[0].dataValue = props.moteusCANID;
+  moteuesDataChoice[0].dataValue.value = props.moteusCANID;
   
 
   // FULL
@@ -87,7 +96,7 @@ function initialize() {
   }
 
   setupSubscriber()
-  setInterval(readDataCallback, 100);
+  setInterval(readDataCallback, UPDATE_DATA_MS);
 
 };
 
@@ -104,13 +113,17 @@ function setupSubscriber(){
 
 
 function readDataCallback(){
-  //let json : any = JSON.stringify(sub.value)
-  let json = JSON.parse(sub.value)
+  if (moteuesDataChoice != undefined) {
+   //console.log(moteuesDataChoice[0].shouldRecordData.value)
 
-  // console.log("AAAAAAAAAAAAAAAAAAA")
-  // console.log(json)
-  
-  //console.log(json[0] + json[1] + json[2] + json[3] + json[4])
+  }
+
+
+  if (sub.value == "" || sub.value == undefined) {
+    return -1
+  }
+
+  let json = JSON.parse(sub.value)
 
   // Moteus Entries
   for (let entry = 0; entry < json.moteusMotorLength; entry++){
@@ -119,14 +132,12 @@ function readDataCallback(){
     
     //check if this entry is ours via canid
     if (moteusMotorEntry.canID == props.moteusCANID) {
-      console.log("BBBBBBBBBBBB")
-      console.log(moteusMotorEntry)
-      moteuesDataChoice[1].dataValue.value = String(moteusMotorEntry.position).replace("\"","").substring(0,4);
-      moteuesDataChoice[2].dataValue.value = String(moteusMotorEntry.velocity).replace("\"","").substring(0,4);
-      moteuesDataChoice[3].dataValue.value = String(moteusMotorEntry.torque).replace("\"","").substring(0,4);
-      moteuesDataChoice[4].dataValue.value = String(moteusMotorEntry.temperature).replace("\"","").substring(0,4);
-      moteuesDataChoice[5].dataValue.value = String(moteusMotorEntry.power).replace("\"","").substring(0,4);
-      moteuesDataChoice[6].dataValue.value = String(moteusMotorEntry.inputVoltage).replace("\"","").substring(0,4);
+      moteuesDataChoice[1].dataValue.value = String(moteusMotorEntry.position).substring(0,6);
+      moteuesDataChoice[2].dataValue.value = String(moteusMotorEntry.velocity).substring(0,6);
+      moteuesDataChoice[3].dataValue.value = String(moteusMotorEntry.torque).substring(0,6);
+      moteuesDataChoice[4].dataValue.value = String(moteusMotorEntry.temperature).substring(0,6);
+      moteuesDataChoice[5].dataValue.value = String(moteusMotorEntry.power).substring(0,6);
+      moteuesDataChoice[6].dataValue.value = String(moteusMotorEntry.inputVoltage).substring(0,6);
     }
 
 
@@ -136,8 +147,7 @@ function readDataCallback(){
 
 
 function itemClicked(itemName: String) {
-  //alert(itemName)
-  let mything = getMoteusDataObjectFromName(itemName);
+  let mything = getMoteusDataObjectFromIdentifier(itemName);
   if (mything != null) {
     mything.isSelected.value = !mything.isSelected.value;
   }
@@ -145,9 +155,29 @@ function itemClicked(itemName: String) {
 
 }
 
+let recordButtonText = ref("Start Recording")
 
 
-function getMoteusDataObjectFromName(itemName: String){
+function recordButtonPressed(){
+  if (!isRecordingData) {
+    recordButtonText.value = "Stop Recording" 
+
+    
+  }
+  else {
+    recordButtonText.value = "Start Recording" 
+
+  }
+
+  isRecordingData = !isRecordingData;
+
+
+
+
+}
+
+
+function getMoteusDataObjectFromIdentifier(itemName: String){
   for (let index = 0; index < moteuesDataChoice.length; index++) {
     if (moteuesDataChoice[index].identifier == itemName) {
       return moteuesDataChoice[index];
@@ -155,6 +185,24 @@ function getMoteusDataObjectFromName(itemName: String){
   }
 
   return null;
+}
+
+function getMoteusDataObjectFromName(itemName: String){
+  for (let index = 0; index < moteuesDataChoice.length; index++) {
+    if (moteuesDataChoice[index].prettyName == itemName) {
+      return moteuesDataChoice[index];
+    }
+  }
+
+  return null;
+}
+
+function checkboxClicked(name: String){
+  let dataEntry = getMoteusDataObjectFromName(name)
+  if (dataEntry != null) {
+    dataEntry.shouldRecordData.value = !dataEntry.shouldRecordData.value
+    console.log(name + "" + dataEntry.shouldRecordData.value)
+  }
 }
 
 </script>
@@ -188,13 +236,19 @@ function getMoteusDataObjectFromName(itemName: String){
 
       </div>
 
+      <div>
+        <button id="record_button" v-bind:class="{'record-button-green': !isRecordingData, 'record-button-red': isRecordingData}" @click="recordButtonPressed">{{ recordButtonText }}</button>
+      </div>
+
     
       <div>
         <TelemetryDataDisplay 
           v-for="(item) in moteuesDataChoice"
           v-bind:itemName="item.prettyName"
           v-bind:isSelected="item.isSelected.value"
-          v-bind:value="item.dataValue">
+          v-bind:value="item.dataValue.value"
+          v-bind:shouldRecordData="item.shouldRecordData.value"
+          @checkboxClicked="checkboxClicked">
         </TelemetryDataDisplay>
       </div>
 
@@ -243,6 +297,29 @@ function getMoteusDataObjectFromName(itemName: String){
   border: none;
   border-radius: 10px;
 }
+
+.record-button-green {
+  background-color: rgb(48, 182, 48);
+  color: white;
+  padding: 8px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  margin-top: 5px;
+}
+
+.record-button-red{
+  background-color: rgb(255, 0, 0);
+  color: white;
+  padding: 8px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  margin-top: 5px;
+}
+
+
+
 
 .dropdown {
   position: relative;

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -162,10 +162,23 @@ function recordButtonPressed(){
   if (!isRecordingData) {
     recordButtonText.value = "Stop Recording" 
 
+    //Create file
+    
     
   }
   else {
     recordButtonText.value = "Start Recording" 
+
+    // const data = JSON.stringify({'hello': 1})
+    // const blob = new Blob([data], {type: 'text/plain'})
+    // const e = document.createEvent('MouseEvents'),
+    // a = document.createElement('a');
+    // a.download = "test.json";
+    // a.href = window.URL.createObjectURL(blob);
+    // a.dataset.downloadurl = ['text/json', a.download, a.href].join(':');
+    // //idk I copy pasted this code
+    // e.initEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+    // a.dispatchEvent(e);
 
   }
 

--- a/src/components/MoteusMotorTelemetry.vue
+++ b/src/components/MoteusMotorTelemetry.vue
@@ -187,7 +187,13 @@ function recordButtonPressed(){
 
     }
 
-    console.log(csvString)
+    const blob = new Blob([csvString], {type: 'text.csv'})
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    let now = new Date()
+    a.download = props.displayName + " " + now.getHours() % 12 + "_" + ((now.getMinutes() < 10 ? '0' : '') + now.getMinutes()) + ".csv"
+    a.href = url;
+    a.click();
 
   }
 

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -1,18 +1,16 @@
-<script>
-    export default{
-        props: {
-            itemName: String,
-            isSelected: Boolean,
-            value: String
-        }
-    }
+<script setup>
+
+    const props = defineProps(['itemName', 'isSelected', 'value', 'shouldRecordData']);
 
 </script>
 
 
 <template>
     <div v-if="isSelected" class="mycontainer">
-        <b>{{ itemName }}</b>
+        <div>
+            <input @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
+            <b>{{ itemName }}</b>
+        </div>
         <b>{{ value }}</b>
     </div>
 
@@ -24,6 +22,14 @@
 .mycontainer {
   display: flex;
   
+}
+
+.checkbox-style{
+    margin-right: 2px;
+}
+
+input[type="checkbox"] {
+  accent-color: rgb(48, 182, 48);;
 }
 
 </style>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -8,7 +8,9 @@
 <template>
     <div v-if="isSelected" class="mycontainer">
         <div>
-            <input v-if="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
+            <KeepAlive>
+                <input v-show="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
+            </KeepAlive>
             <b>{{ itemName }}</b>
         </div>
         <b>{{ value }}</b>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -9,7 +9,6 @@
     <div v-if="isSelected" class="mycontainer">
         <div >
             <input v-if="showAllFeatures" v-show="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
-            
             <b>{{ itemName }}</b>
         </div>
         <b>{{ value }}</b>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -1,0 +1,29 @@
+<script>
+    export default{
+        props: {
+            itemName: String,
+            isSelected: Boolean,
+            value: String
+        }
+    }
+
+</script>
+
+
+<template>
+    <div v-if="isSelected">
+        <b>{{ itemName }}</b>
+        <b>{{ value }}</b>
+    </div>
+
+</template>
+
+
+<style lang="scss">
+
+.mycontainer {
+  display: flex;
+  
+}
+
+</style>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -1,16 +1,15 @@
 <script setup>
 
-    const props = defineProps(['itemName', 'isSelected', 'value', 'shouldRecordData', 'shouldShowCheckBox']);
+    const props = defineProps(['itemName', 'isSelected', 'value', 'shouldRecordData', 'shouldShowCheckBox', "showAllFeatures"]);
 
 </script>
 
 
 <template>
     <div v-if="isSelected" class="mycontainer">
-        <div>
-            <KeepAlive>
-                <input v-show="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
-            </KeepAlive>
+        <div >
+            <input v-if="showAllFeatures" v-show="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
+            
             <b>{{ itemName }}</b>
         </div>
         <b>{{ value }}</b>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -1,6 +1,6 @@
 <script setup>
 
-    const props = defineProps(['itemName', 'isSelected', 'value', 'shouldRecordData']);
+    const props = defineProps(['itemName', 'isSelected', 'value', 'shouldRecordData', 'shouldShowCheckBox']);
 
 </script>
 
@@ -8,7 +8,7 @@
 <template>
     <div v-if="isSelected" class="mycontainer">
         <div>
-            <input @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
+            <input v-if="shouldShowCheckBox" @click="$emit('checkboxClicked', itemName)" class="checkbox-style" type="checkbox" title="Select to include this value when recording data into a .csv file">
             <b>{{ itemName }}</b>
         </div>
         <b>{{ value }}</b>

--- a/src/components/TelemetryDataDisplay.vue
+++ b/src/components/TelemetryDataDisplay.vue
@@ -11,7 +11,7 @@
 
 
 <template>
-    <div v-if="isSelected">
+    <div v-if="isSelected" class="mycontainer">
         <b>{{ itemName }}</b>
         <b>{{ value }}</b>
     </div>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -4,18 +4,17 @@
 </script>
 <template>
   <div class="page">
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="1" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
     
   </div>
 </template>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -4,15 +4,34 @@
 </script>
 <template>
   <div class="page">
-    <MoteusMotorTelemetry></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="1" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="420" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    
   </div>
 </template>
 
 <style lang="scss" scoped>
 .page {
-
-
+  display: flex;
+  flex-wrap: wrap;
+  padding: 5px;
+  margin: 5px;
+  justify-content: center;
   
+  
+}
+
+.moteus-motor{
+  margin: 5px  
 }
 </style>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -1,20 +1,42 @@
 <!-- All information about rover like motor speed etc, position, potential record and export to csv -->
 <script setup lang="ts">
   import MoteusMotorTelemetry from '../components/MoteusMotorTelemetry.vue'
+  import missionControlSub from '../roslib/missionControlSub'
+  import {ref, onMounted, inject} from 'vue'
+  import { Ros } from 'roslib';
+
+  const ros = inject<Ros>('ros')
+  let subscriberData : any = ref(null);
+  let isLoaded = ref(false)
+
+  onMounted(() => initialize());
+
+  function initialize(){
+    if (ros != null){
+      subscriberData.value = missionControlSub(ros)
+    }
+
+    isLoaded.value = true;
+  }
+
+
+
+
+
 </script>
 <template>
   <div class="page">
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
     
   </div>
 </template>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -8,6 +8,7 @@
   const ros = inject<Ros>('ros')
   let subscriberData : any = ref(null);
   let isLoaded = ref(false)
+  let update_time_ms = ref(100)
 
   onMounted(() => initialize());
 
@@ -25,18 +26,25 @@
 
 </script>
 <template>
-  <div class="page">
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-    <MoteusMotorTelemetry class="moteus-motor" v-bind:dataSub="subscriberData" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+  <div >
+    <div class="period-input-container">
+      <b class="period-text">Update Delay in ms</b>
+      <input class="period-input" min="4" v-model="update_time_ms" type="number" title="Number of milliseconds between each time it polls for data. Affects recording as well"/>
+    </div>
+    <div class="page">
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+
+    </div>
     
   </div>
 </template>
@@ -50,6 +58,22 @@
   justify-content: center;
   
   
+}
+
+.period-input-container{
+  display: flex;
+  justify-content: center;
+  margin: 10px;
+  
+}
+
+.period-input{
+  
+  border-radius: 5px;
+}
+
+.period-text{
+  margin-right: 5px;
 }
 
 .moteus-motor{

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -5,6 +5,8 @@
   import {ref, onMounted, inject} from 'vue'
   import { Ros } from 'roslib';
 
+  // We will pass one single subscriber to all the children in order to prevent
+  // subscriber spam
   const ros = inject<Ros>('ros')
   let subscriberData : any = ref(null);
   let update_time_ms = ref(100)
@@ -15,12 +17,7 @@
     if (ros != null){
       subscriberData.value = missionControlSub(ros)
     }
-
-
   }
-
-
-
 
 
 </script>
@@ -31,6 +28,7 @@
       <input class="period-input" min="4" v-model="update_time_ms" type="number" title="Number of milliseconds between each time it polls for data. Affects recording as well"/>
     </div>
     <div class="page">
+      <!-- Idk why, but in order to NOT showAllFeatures, do showAllFeatures="" <- writing anything besides an empty string does not work to make it "false" -->
       <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
       <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
       <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -1,12 +1,18 @@
 <!-- All information about rover like motor speed etc, position, potential record and export to csv -->
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  import MoteusMotorTelemetry from '../components/MoteusMotorTelemetry.vue'
+</script>
 <template>
   <div class="page">
-    <h1>Not yet Implemented</h1>
+    <MoteusMotorTelemetry></MoteusMotorTelemetry>
+    <MoteusMotorTelemetry></MoteusMotorTelemetry>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .page {
+
+
+  
 }
 </style>

--- a/src/pages/Telemetry.vue
+++ b/src/pages/Telemetry.vue
@@ -7,7 +7,6 @@
 
   const ros = inject<Ros>('ros')
   let subscriberData : any = ref(null);
-  let isLoaded = ref(false)
   let update_time_ms = ref(100)
 
   onMounted(() => initialize());
@@ -17,7 +16,7 @@
       subscriberData.value = missionControlSub(ros)
     }
 
-    isLoaded.value = true;
+
   }
 
 
@@ -32,17 +31,17 @@
       <input class="period-input" min="4" v-model="update_time_ms" type="number" title="Number of milliseconds between each time it polls for data. Affects recording as well"/>
     </div>
     <div class="page">
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
-      <MoteusMotorTelemetry class="moteus-motor" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="25" displayName="Front Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="24" displayName="Mid Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="23" displayName="Back Left Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="22" displayName="Front Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="21" displayName="Mid Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="20" displayName="Back Right Drive Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="1" displayName="Shoulder Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="2" displayName="Elbow Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="3" displayName="Left Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="4" displayName="Right Wrist Motor" preset="FULL"></MoteusMotorTelemetry>
+      <MoteusMotorTelemetry class="moteus-motor" showAllFeatures="true" v-bind:update_ms="update_time_ms" v-bind:dataSub="subscriberData" moteusCANID="5" displayName="Turntable Motor" preset="FULL"></MoteusMotorTelemetry>
 
     </div>
     

--- a/src/roslib/missionControlSub.ts
+++ b/src/roslib/missionControlSub.ts
@@ -1,0 +1,22 @@
+import ROSLIB, { Ros } from 'roslib';
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+//in order to have reactive behavior, store the ros data in a ref
+let missionControlData = ref<String>();
+//Since we are going to return exampleData anyway, use typeof
+export default function missionControlSub(ros: ROSLIB.Ros): typeof missionControlData {
+  let exampleTopic = new ROSLIB.Topic({
+    ros,
+    //topic name
+    name: '/mission_control_updater',
+    //more message types at https://docs.ros.org/en/melodic/api/std_msgs/html/index-msg.html
+    messageType: 'std_msgs/String',
+  });
+  
+  //subscribe to topic and sets ref data
+  exampleTopic.subscribe<String>((message) => {
+    missionControlData.value = message.data;
+  });
+
+  return missionControlData;
+}


### PR DESCRIPTION
This adds a way to display telemetry data for the mission control.

The following features are this:
- Select what data to display
- Select a default preset that shows a predetermined amount of data. `FULL` shows everything by default
- An easy-ish way to add more data entries to display
- Hide unnecessary features (checkboxes, buttons, etc) in order to fit in the moteus modules in other tabs 
- Saving data as .csv file
   - Selecting what data to save
   - Saves as a download to your downloads folder
 - Change the speed at which the data is polled. As of now, the robot code publishes the mission control JSON every 10ms 
   - The minimum speed on the mission control is every 4ms, and up to an infinite amount  