### PR TITLE
Transport communications over CBOR instead of JSON

### DIFF
--- a/src/roslib/cameraSub.ts
+++ b/src/roslib/cameraSub.ts
@@ -16,10 +16,12 @@ export default function cameraSub(
       name: `/video_frames${i}`,
       //https://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/CompressedImage.html
       messageType: 'sensor_msgs/msg/CompressedImage',
+      compression: "cbor",
     });
     console.log(cameraTopic);
     cameraTopic.subscribe<CompressedImage>((message) => {
-      compressedImage[i] = 'data:image/jpg;base64,' + message.data;
+      const base64 = btoa(Array(message.data.length).fill("").map((_, i) => String.fromCharCode(message.data[i])).join(""));
+      compressedImage[i] = 'data:image/jpg;base64,' + base64;
     });
   }
   return compressedImage;

--- a/src/roslib/controllerPub.ts
+++ b/src/roslib/controllerPub.ts
@@ -10,6 +10,7 @@ export default function controllerPub(ros: ROSLIB.Ros, pubName: string, input: n
       name: pubName,
       //more message types at https://docs.ros.org/en/melodic/api/std_msgs/html/index-msg.html
       messageType: 'std_msgs/Float32',
+      compression: "cbor",
     });
     // Function to publish a heartbeat message
     let data = new ROSLIB.Message({

--- a/src/roslib/examplePub.ts
+++ b/src/roslib/examplePub.ts
@@ -10,6 +10,7 @@ export default function examplePub(ros: ROSLIB.Ros, exampleInput: number) {
     name: '/exampleData',
     //more message types at https://docs.ros.org/en/melodic/api/std_msgs/html/index-msg.html
     messageType: 'std_msgs/Int32',
+    compression: "cbor",
   });
   // Function to publish a heartbeat message
   let data = new ROSLIB.Message({

--- a/src/roslib/exampleSub.ts
+++ b/src/roslib/exampleSub.ts
@@ -11,6 +11,7 @@ export default function exampleSub(ros: ROSLIB.Ros): typeof exampleData {
     name: '/exampleData',
     //more message types at https://docs.ros.org/en/melodic/api/std_msgs/html/index-msg.html
     messageType: 'std_msgs/Int32',
+    compression: "cbor",
   });
   //subscribe to topic and sets ref data
   exampleTopic.subscribe<number>((message) => {

--- a/src/roslib/genericPub.ts
+++ b/src/roslib/genericPub.ts
@@ -8,6 +8,7 @@ export default function examplePub(ros: ROSLIB.Ros, input, passedName: string, m
     ros,
     name: passedName,
     messageType: messageType,
+    compression: "cbor",
   });
   // Function to publish a heartbeat message
   let data = new ROSLIB.Message({

--- a/src/roslib/heartbeatPub.ts
+++ b/src/roslib/heartbeatPub.ts
@@ -8,7 +8,8 @@ export default function heartbeatPub(ros: ROSLIB.Ros, input: boolean, interval: 
   let heartbeat_topic = new ROSLIB.Topic({
     ros,
     name: '/heartbeat',
-    messageType: 'std_msgs/Bool'
+    messageType: 'std_msgs/Bool',
+    compression: "cbor",
   });
 
   let heartbeatData = new ROSLIB.Message({

--- a/src/roslib/missionControlSub.ts
+++ b/src/roslib/missionControlSub.ts
@@ -11,8 +11,9 @@ export default function missionControlSub(ros: ROSLIB.Ros): typeof missionContro
     name: '/mission_control_updater',
     //more message types at https://docs.ros.org/en/melodic/api/std_msgs/html/index-msg.html
     messageType: 'std_msgs/String',
+    compression: "cbor",
   });
-  
+
   //subscribe to topic and sets ref data
   exampleTopic.subscribe<String>((message) => {
     missionControlData.value = message.data;


### PR DESCRIPTION
CBOR is more efficient than JSON, and moving over to it automatically encodes images in binary rather than base64, which should reduce bandwidth usage by ~30%. Currently roslibjs doesn't support cbor for sending messages, although we could probably implement it if needed. I suspect most of the data is coming from the rover and not the other way around, though.