### PR TITLE
Make createSubscriber and createPublisher cheap

### DIFF
--- a/src/lib/roslibUtils/createPublisher.ts
+++ b/src/lib/roslibUtils/createPublisher.ts
@@ -26,7 +26,7 @@ export function createPublisher<T extends TopicType>(options: {
   topicType: T;
 }): Publisher<T> {
   const ros = useRoslibStore();
-  return createPublisherForRos(ros.ros, options);
+  return createPublisherForRos(ros.getTopic, options);
 }
 
 /**
@@ -34,20 +34,14 @@ export function createPublisher<T extends TopicType>(options: {
  * default one.
  */
 export function createPublisherForRos<T extends TopicType>(
-  ros: ROSLIB.Ros,
+  getTopic: <T>(name: string, type: string) => ROSLIB.Topic<T>,
   options: {
     topicName: string;
     topicType: T;
   },
 ): Publisher<T> {
   const { topicName, topicType } = options;
-  const topic = new ROSLIB.Topic<TopicTypeMap[T]>({
-    ros,
-    name: topicName,
-    messageType: topicType,
-    compression: 'cbor',
-    reconnect_on_close: true,
-  });
+  const topic = getTopic<TopicTypeMap[T]>(topicName, topicType);
 
   const publish: Publisher<T>['publish'] = (data, options) => {
     const { isDebugging } = options || {};

--- a/src/pages/Cameras.vue
+++ b/src/pages/Cameras.vue
@@ -1,40 +1,12 @@
 <!-- Camera: Shows all the cameras, can select which cameras to show -->
 <script setup lang="ts">
 import CameraModule from '@/components/camera/CameraModule.vue';
-import { createSubscriber } from '@/lib/roslibUtils/createSubscriber';
-import type { CompressedImage } from '@/lib/roslibUtils/rosTypes';
-import { onMounted, type Ref, ref } from 'vue';
-
-const blackImage =
-  'data:image/jpg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==';
-
-const cameraOne = createSubscriber({
-  topicName: `video_frames0`,
-  topicType: 'sensor_msgs/msg/CompressedImage',
-});
-const cameraOneURL = ref<string>(blackImage);
-
-const cameraTwo = createSubscriber({
-  topicName: `video_frames1`,
-  topicType: 'sensor_msgs/msg/CompressedImage',
-});
-const cameraTwoURL = ref<string>(blackImage);
-
-const createCalback = (cameraURL: Ref<string>) => (message: CompressedImage) => {
-  const blob = new Blob([message.data], { type: 'image/' + message.format });
-  cameraURL.value = URL.createObjectURL(blob);
-};
-
-onMounted(() => {
-  cameraOne.start({ callback: createCalback(cameraOneURL) });
-  cameraTwo.start({ callback: createCalback(cameraTwoURL) });
-});
 </script>
 
 <template>
   <div class="two-by-three-grid-page">
-    <CameraModule :camera-sub="cameraOne" :camera-url="cameraOneURL" camera-name="Front" />
-    <CameraModule :camera-sub="cameraTwo" :camera-url="cameraTwoURL" camera-name="Back" />
+    <CameraModule :camera-id="0" camera-name="Front" />
+    <CameraModule :camera-id="1" camera-name="Back" />
     <h1>Not yet Implemented</h1>
     <h1>Not yet Implemented</h1>
     <h1>Not yet Implemented</h1>


### PR DESCRIPTION
This creates a cache of topics such that creating new subscribers and publishers don't incur extra network requests.
If no subscribers are listening to a topic, then messages won't be sent to it.