### PR TITLE
Add Ping, Modify Operation State Store, and Slight UI Changes.

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -7,6 +7,7 @@
   --error: #e50000;
   --correct: #30b630;
   --white: #fafafa;
+  --space-purple: #29293d;
 }
 *,
 ::before,

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -29,15 +29,15 @@ const setCurrentTab = (newValue: number) => {
 };
 
 const pingSubscriber = createSubscriber({
-  topicName: "/ping",
-  topicType: "std_msgs/Float32",
-  startingDefaultValue: {data: 0.0},
-})
+  topicName: '/ping',
+  topicType: 'std_msgs/Float32',
+  startingDefaultValue: { data: 0.0 },
+});
 
 onMounted(() => {
   operation.operationState.start();
   pingSubscriber.start();
-})
+});
 
 type PageIcon = { icon: object; label: string; helperText: string }[];
 
@@ -118,7 +118,7 @@ const pageIconArr: PageIcon = [
           id="disable-button"
           title="Disabled"
           :class="{ checked: operation.operationState.msg?.data === 'disabled' }"
-          @click="operation.setOperationState({data: 'disabled'})"
+          @click="operation.setOperationState({ data: 'disabled' })"
         >
           Disable
         </button>
@@ -126,7 +126,7 @@ const pageIconArr: PageIcon = [
           id="teleoperation-button"
           title="TeleOperation"
           :class="{ checked: operation.operationState.msg?.data === 'teleoperation' }"
-          @click="operation.setOperationState({data: 'teleoperation'})"
+          @click="operation.setOperationState({ data: 'teleoperation' })"
         >
           TeleOp
         </button>
@@ -134,7 +134,7 @@ const pageIconArr: PageIcon = [
           id="autonomous-button"
           title="Autonomous"
           :class="{ checked: operation.operationState.msg?.data === 'autonomous' }"
-          @click="operation.setOperationState({data: 'autonomous'})"
+          @click="operation.setOperationState({ data: 'autonomous' })"
         >
           Auto
         </button>
@@ -174,7 +174,13 @@ const pageIconArr: PageIcon = [
       </div>
       <div class="container">
         <h4 id="status">Ping</h4>
-        <h4>{{ pingSubscriber.msg?.value?.data ? (Math.round(pingSubscriber.msg?.value?.data * 1000)) + 'ms' : "N/A" }}</h4>
+        <h4>
+          {{
+            pingSubscriber.msg?.value?.data
+              ? Math.round(pingSubscriber.msg?.value?.data * 1000) + 'ms'
+              : 'N/A'
+          }}
+        </h4>
       </div>
     </section>
   </nav>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -15,6 +15,7 @@ import ControllerIcon from 'vue-material-design-icons/ControllerClassic.vue';
 import { useRoslibStore } from '@/store/roslibStore';
 import { useControllerStore } from '@/store/controllerStore';
 import { useOperationStateStore } from '../store/operationStateStore';
+import { onMounted } from 'vue';
 
 //TODO implement latency
 
@@ -25,6 +26,10 @@ const currentTab = ref(0);
 const setCurrentTab = (newValue: number) => {
   currentTab.value = newValue;
 };
+
+onMounted(() => {
+  operation.operationState.start();
+})
 
 type PageIcon = { icon: object; label: string; helperText: string }[];
 
@@ -104,24 +109,24 @@ const pageIconArr: PageIcon = [
         <button
           id="disable-button"
           title="Disabled"
-          :class="{ checked: operation.operationState === 'disabled' }"
-          @click="operation.setOperationState('disabled')"
+          :class="{ checked: operation.operationState.msg?.data === 'disabled' }"
+          @click="operation.setOperationState({data: 'disabled'})"
         >
           Disable
         </button>
         <button
           id="teleoperation-button"
           title="TeleOperation"
-          :class="{ checked: operation.operationState === 'teleoperation' }"
-          @click="operation.setOperationState('teleoperation')"
+          :class="{ checked: operation.operationState.msg?.data === 'teleoperation' }"
+          @click="operation.setOperationState({data: 'teleoperation'})"
         >
           TeleOp
         </button>
         <button
           id="autonomous-button"
           title="Autonomous"
-          :class="{ checked: operation.operationState === 'autonomous' }"
-          @click="operation.setOperationState('autonomous')"
+          :class="{ checked: operation.operationState.msg?.data === 'autonomous' }"
+          @click="operation.setOperationState({data: 'autonomous'})"
         >
           Auto
         </button>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -16,6 +16,7 @@ import { useRoslibStore } from '@/store/roslibStore';
 import { useControllerStore } from '@/store/controllerStore';
 import { useOperationStateStore } from '../store/operationStateStore';
 import { onMounted } from 'vue';
+import { createSubscriber } from '@/lib/roslibUtils/createSubscriber';
 
 //TODO implement latency
 
@@ -27,8 +28,15 @@ const setCurrentTab = (newValue: number) => {
   currentTab.value = newValue;
 };
 
+const pingSubscriber = createSubscriber({
+  topicName: "/ping",
+  topicType: "std_msgs/Float32",
+  startingDefaultValue: {data: 0.0},
+})
+
 onMounted(() => {
   operation.operationState.start();
+  pingSubscriber.start();
 })
 
 type PageIcon = { icon: object; label: string; helperText: string }[];
@@ -166,7 +174,7 @@ const pageIconArr: PageIcon = [
       </div>
       <div class="container">
         <h4 id="status">Ping</h4>
-        <h4>{{ roslib.latency + 'ms' }}</h4>
+        <h4>{{ pingSubscriber.msg?.value?.data ? (Math.round(pingSubscriber.msg?.value?.data * 1000)) + 'ms' : "N/A" }}</h4>
       </div>
     </section>
   </nav>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -16,9 +16,6 @@ import { useRoslibStore } from '@/store/roslibStore';
 import { useControllerStore } from '@/store/controllerStore';
 import { useOperationStateStore } from '../store/operationStateStore';
 import { onMounted } from 'vue';
-import { createSubscriber } from '@/lib/roslibUtils/createSubscriber';
-
-//TODO implement latency
 
 const roslib = useRoslibStore();
 const controller = useControllerStore();
@@ -28,14 +25,8 @@ const setCurrentTab = (newValue: number) => {
   currentTab.value = newValue;
 };
 
-const pingSubscriber = createSubscriber({
-  topicName: '/ping',
-  topicType: 'std_msgs/Float32',
-});
-
 onMounted(() => {
   operation.operationState.start();
-  pingSubscriber.start();
 });
 
 type PageIcon = { icon: object; label: string; helperText: string }[];
@@ -171,14 +162,10 @@ const pageIconArr: PageIcon = [
           :class="{ green: controller.isGamepadConnected, red: !controller.isGamepadConnected }"
         />
       </div>
-      <div id = "ping_container" class="container">
+      <div id="ping_container" class="container">
         <h4 id="status">Ping</h4>
         <h5>
-          {{
-            pingSubscriber.msg?.value?.data
-              ? Math.round(pingSubscriber.msg?.value?.data * 1000) + 'ms'
-              : 'N/A'
-          }}
+          {{ roslib.latency ? Math.round(roslib.latency) + 'ms' : 'N/A' }}
         </h5>
       </div>
     </section>
@@ -221,8 +208,7 @@ nav {
     align-items: center;
     justify-content: center;
 
-    &#ping_container
-    {
+    &#ping_container {
       justify-content: start;
       margin: 0.2rem;
       max-width: 2rem;

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -31,7 +31,6 @@ const setCurrentTab = (newValue: number) => {
 const pingSubscriber = createSubscriber({
   topicName: '/ping',
   topicType: 'std_msgs/Float32',
-  startingDefaultValue: { data: 0.0 },
 });
 
 onMounted(() => {
@@ -172,15 +171,15 @@ const pageIconArr: PageIcon = [
           :class="{ green: controller.isGamepadConnected, red: !controller.isGamepadConnected }"
         />
       </div>
-      <div class="container">
+      <div id = "ping_container" class="container">
         <h4 id="status">Ping</h4>
-        <h4>
+        <h5>
           {{
             pingSubscriber.msg?.value?.data
               ? Math.round(pingSubscriber.msg?.value?.data * 1000) + 'ms'
               : 'N/A'
           }}
-        </h4>
+        </h5>
       </div>
     </section>
   </nav>
@@ -188,10 +187,8 @@ const pageIconArr: PageIcon = [
 
 <style lang="scss" scoped>
 nav {
-  padding: 0 0 0 1rem;
   grid-area: nav;
   display: flex;
-  align-items: center;
   height: var(--nav-bar-size);
   background-color: var(--black);
   h1,
@@ -223,18 +220,28 @@ nav {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+
+    &#ping_container
+    {
+      justify-content: start;
+      margin: 0.2rem;
+      max-width: 2rem;
+    }
   }
   #logo-section {
     display: flex;
     align-items: center;
     flex-shrink: 0;
+    background-color: var(--space-purple);
 
     #logo {
       max-width: 100%;
       max-height: 3rem;
+      margin: 0 0 0 1rem;
     }
     #logo-text {
-      margin: 0 1rem;
+      margin: 0 1rem 0 0.8rem;
+      font-size: 1.5rem;
     }
   }
   #page-section {
@@ -243,15 +250,15 @@ nav {
     overflow-y: hidden;
     scrollbar-width: none;
     flex-grow: 1;
-    border-right: 1px solid var(--white);
-    border-left: 1px solid var(--white);
+    border-right: 2px solid var(--white);
+    border-left: 2px solid var(--white);
   }
   #states-section {
     display: flex;
     gap: 1.75rem;
     height: var(--nav-bar-size);
     padding: 0 2rem 0 1.5rem;
-    background-color: hsl(240, 20%, 20%);
+    background-color: var(--space-purple);
 
     #operation-selector {
       margin: auto 0;

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -26,7 +26,7 @@ const setCurrentTab = (newValue: number) => {
 };
 
 onMounted(() => {
-  operation.operationState.start();
+  operation.operationStateSub.start();
 });
 
 type PageIcon = { icon: object; label: string; helperText: string }[];
@@ -107,7 +107,7 @@ const pageIconArr: PageIcon = [
         <button
           id="disable-button"
           title="Disabled"
-          :class="{ checked: operation.operationState.msg?.data === 'disabled' }"
+          :class="{ checked: operation.getOperationState() === 'disabled' }"
           @click="operation.setOperationState({ data: 'disabled' })"
         >
           Disable
@@ -115,7 +115,7 @@ const pageIconArr: PageIcon = [
         <button
           id="teleoperation-button"
           title="TeleOperation"
-          :class="{ checked: operation.operationState.msg?.data === 'teleoperation' }"
+          :class="{ checked: operation.getOperationState() === 'teleoperation' }"
           @click="operation.setOperationState({ data: 'teleoperation' })"
         >
           TeleOp
@@ -123,7 +123,7 @@ const pageIconArr: PageIcon = [
         <button
           id="autonomous-button"
           title="Autonomous"
-          :class="{ checked: operation.operationState.msg?.data === 'autonomous' }"
+          :class="{ checked: operation.getOperationState() === 'autonomous' }"
           @click="operation.setOperationState({ data: 'autonomous' })"
         >
           Auto

--- a/src/lib/roslibUtils/createSubscriber.ts
+++ b/src/lib/roslibUtils/createSubscriber.ts
@@ -21,7 +21,7 @@ export interface Subscriber<T extends TopicType, CB extends boolean> {
    * @param options - are the options used during the duration of this startup.
    * @param options.callback - is a callback that will be ran when data is received, containing the data itself.
    * @param options.defaultValue - is an optional value to set `msg` to after subscribing.
-   * @param options.isDebugging - should we show debug output?
+   * @param options.isDebugging - prints out message when subscriber receives message.
    */
   start: (options?: {
     callback?: CB extends true ? (message: TopicTypeMap[T]) => void : never;

--- a/src/lib/roslibUtils/roslibManager.ts
+++ b/src/lib/roslibUtils/roslibManager.ts
@@ -20,7 +20,7 @@ export interface RoslibManager {
   stop: Ref<boolean>;
   isWebSocketConnected: Ref<boolean>;
   latency: Ref<number>;
-  getTopic: <T>(name: string, type: string) => ROSLIB.Topic<T>
+  getTopic: <T>(name: string, type: string) => ROSLIB.Topic<T>;
 }
 
 /**

--- a/src/lib/roslibUtils/roslibManager.ts
+++ b/src/lib/roslibUtils/roslibManager.ts
@@ -20,7 +20,7 @@ export interface RoslibManager {
   stop: Ref<boolean>;
   isWebSocketConnected: Ref<boolean>;
   latency: Ref<number>;
-  getTopic: <T>(name: string, type: string) => ROSLIB.Topic<T>;
+  getTopic: <T>(name: string, type: string) => ROSLIB.Topic<T>
 }
 
 /**
@@ -36,9 +36,11 @@ export function roslibManager(): RoslibManager {
   let heartbeatRunning: boolean = false;
   let heartbeatTime: number = 0;
 
+  const sendTime: Ref<number> = ref(0);
+  const latency: Ref<number> = ref(0);
+
   const stop: Ref<boolean> = ref(false);
   const isWebSocketConnected: Ref<boolean> = ref(false);
-  const latency: Ref<number> = ref(0);
 
   let serverHost: string | null = settings.settings.value.websocketAddress;
 
@@ -101,6 +103,7 @@ export function roslibManager(): RoslibManager {
       callback: (msg) => {
         if (msg.data) {
           heartbeatTime = Date.now();
+          latency.value = (Date.now() - sendTime.value) / 2;
         }
       },
     });
@@ -141,6 +144,7 @@ export function roslibManager(): RoslibManager {
       }
 
       heartbeatPub.publish(heartbeatData);
+      sendTime.value = Date.now();
     }, HEARTBEAT_SEND_INTERVAL);
   }
 

--- a/src/store/operationStateStore.ts
+++ b/src/store/operationStateStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { createPublisher } from '@/lib/roslibUtils/createPublisher';
 import { ref } from 'vue';
+import { createSubscriber } from '@/lib/roslibUtils/createSubscriber';
 
 export type OperationState = 'disabled' | 'teleoperation' | 'autonomous';
 
@@ -9,15 +10,19 @@ export const useOperationStateStore = defineStore('operationType', () => {
     topicName: '/setOperationState',
     topicType: 'std_msgs/String',
   });
-  const operationState = ref<OperationState>('disabled');
+
+  const operationState = createSubscriber({
+    topicName: '/setOperationState',
+    topicType: 'std_msgs/String',
+    startingDefaultValue: {data: 'disabled'}
+  });
 
   /**
    * This function sets the operation state to the specified state and sends out a message on the ros topic to change the state.
    * @param state - the new operation state to set the driver to.
    */
-  function setOperationState(state: OperationState) {
-    operationState.value = state;
-    operationStatePublisher.publish({ data: operationState.value });
+  function setOperationState(state: {data : OperationState}) {
+    operationStatePublisher.publish(state);
   }
 
   // Return all state, getters and functions

--- a/src/store/operationStateStore.ts
+++ b/src/store/operationStateStore.ts
@@ -1,30 +1,35 @@
 import { defineStore } from 'pinia';
 import { createPublisher } from '@/lib/roslibUtils/createPublisher';
-import { ref } from 'vue';
 import { createSubscriber } from '@/lib/roslibUtils/createSubscriber';
 
 export type OperationState = 'disabled' | 'teleoperation' | 'autonomous';
 
 export const useOperationStateStore = defineStore('operationType', () => {
-  const operationStatePublisher = createPublisher({
+  const operationStatePub = createPublisher({
     topicName: '/setOperationState',
     topicType: 'std_msgs/String',
   });
 
-  const operationState = createSubscriber({
+  const operationStateSub = createSubscriber({
     topicName: '/setOperationState',
     topicType: 'std_msgs/String',
     startingDefaultValue: { data: 'disabled' },
   });
 
   /**
-   * This function sets the operation state to the specified state and sends out a message on the ros topic to change the state.
+   * This function publishes to the /setOperationState topic to change the operation state.
    * @param state - the new operation state to set the driver to.
    */
   function setOperationState(state: { data: OperationState }) {
-    operationStatePublisher.publish(state);
+    operationStatePub.publish(state);
+  }
+  /**
+   * This function returns the current operation state.
+   */
+  function getOperationState() {
+    return operationStateSub.msg?.value?.data;
   }
 
   // Return all state, getters and functions
-  return { operationState, setOperationState };
+  return { operationStateSub, setOperationState, getOperationState };
 });

--- a/src/store/operationStateStore.ts
+++ b/src/store/operationStateStore.ts
@@ -14,14 +14,14 @@ export const useOperationStateStore = defineStore('operationType', () => {
   const operationState = createSubscriber({
     topicName: '/setOperationState',
     topicType: 'std_msgs/String',
-    startingDefaultValue: {data: 'disabled'}
+    startingDefaultValue: { data: 'disabled' },
   });
 
   /**
    * This function sets the operation state to the specified state and sends out a message on the ros topic to change the state.
    * @param state - the new operation state to set the driver to.
    */
-  function setOperationState(state: {data : OperationState}) {
+  function setOperationState(state: { data: OperationState }) {
     operationStatePublisher.publish(state);
   }
 


### PR DESCRIPTION
**Base Station States**
In accordance with a request from Adam, I reformatted the operationState store to use a subscriber instead of a ref to help with maintaing the state across the rover and mission control. With this change, the mission control is unable to change its own state once the rover disconnects. However, the rover can still change its own state and not have changes reflected in the mission control while it is disconnected, so there still need to be changes elsewhere to resolve this issue. Additionally, I made some slight reformatting and added a getter method to make getting the state more clear.
**Ping**
Added ping functionality by adding an additional latency output ref from roslibManager.ts. The latency is calculated by storing the time from which the heartbeat to the rover is sent out and is subtracted from the time when the heartbest is received. Then the latency is divided by two to account for the round trip.
**UI Changes**
Finally, I made some slight UI changes to make the icon section purple. I changed some styling with the ping area to account for longer input strings. I also added the purple used as a color ref to global.scss and changed all uses in styling to use this variable.

I would appreciate some feedback on these changes. Thank you for reading and let me know if there is anything else I should add or if you have any questions.